### PR TITLE
Added command to follow link in new tab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pypandoc
 pandocfilters
 tqdm
 dill
+colorama


### PR DESCRIPTION
Title is incorrect. This is my first foray into git.

On macOS 12 with Vim 8.2 and Python 3.9, viewing backlinks fails without installing the Python colorama module. I have added this module to the requirements.